### PR TITLE
[ANA-5235]: Improve redefines-builtin-id

### DIFF
--- a/testdata/redefines-builtin-id.go
+++ b/testdata/redefines-builtin-id.go
@@ -1,5 +1,13 @@
 package fixtures
 
+import "path/filepath"
+
+func renameTestFile(name string, old string, new string) {
+	old = filepath.Join(name, old)
+	new = filepath.Join(name, new) // MATCH /redefinition of the built-in function new/
+	new = filepath.Join(name)
+}
+
 func (this data) vmethod() {
 	nil := true // MATCH /assignment creates a shadow of built-in identifier nil/
 	iota = 1    // MATCH /assignment modifies built-in identifier iota/


### PR DESCRIPTION
I do not see how this lint would be raised on function parameters (as it just considers the function's name). Although, I have fixed it, i.e., only 1 lint per object.